### PR TITLE
Skip bad PR data and output a warning.

### DIFF
--- a/bors.py
+++ b/bors.py
@@ -599,8 +599,13 @@ def main():
             more_pulls = False
         page += 1
 
-    pulls = [ PullReq(cfg, gh, pull) for pull in
-              all_pulls ]
+    pulls = []
+    for pull in all_pulls:
+        p = None
+        try:
+            pulls.append(PullReq(cfg, gh, pull))
+        except:
+            logging.warn("unexpected data in PR #%d; skipping!" % pull["number"])
 
     #
     # We are reconstructing the relationship between three tree-states on the


### PR DESCRIPTION
This fixes errors that occur during PullRequest's constructor to not take down all of bors, but just skip the offending PR.

This is currently happening because if a user deletes their repo fork and then recreates a new one the PR becomes repoless, and bors uses the repo to get at certain pieces of data.
